### PR TITLE
Use the 'name' field to represent population and generation for frontend to use 1 api call.

### DIFF
--- a/controller/ea.go
+++ b/controller/ea.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 )
 
 func CreateEA(res http.ResponseWriter, req *http.Request) {
@@ -50,11 +49,18 @@ func CreateEA(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	var description string
+	if ea.Algorithm == "de" {
+		description = "Differential Evolution (DE)"
+	} else {
+		description = "Evolutionary Algorithm (EA)"
+	}
+
 	row := db.QueryRow(req.Context(), `
 		INSERT INTO run (name, description, type, command, createdBy)
 		VALUES ($1, $2, $3, $4, $5)
 		RETURNING id
-	`, time.Now().Local().String(), "Traditional EA Without GP", "ea", "python -m scoop code.py", user["id"])
+	`, fmt.Sprintf("%d-%d", ea.Generations, ea.PopulationSize), description, "ea", "python -m scoop code.py", user["id"])
 
 	var runID string
 	err = row.Scan(&runID)
@@ -126,6 +132,7 @@ func CreateEA(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	data["runID"] = runID
 	util.JSONResponse(res, http.StatusOK, "It works! 👍🏻", data)
 
 }

--- a/controller/gp.go
+++ b/controller/gp.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 )
 
 func CreateGP(res http.ResponseWriter, req *http.Request) {
@@ -31,13 +30,13 @@ func CreateGP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	ea, err := modules.GPFromJSON(data)
+	gp, err := modules.GPFromJSON(data)
 	if err != nil {
 		util.JSONResponse(res, http.StatusBadRequest, err.Error(), nil)
 		return
 	}
 
-	code, err := ea.Code()
+	code, err := gp.Code()
 	if err != nil {
 		util.JSONResponse(res, http.StatusBadRequest, err.Error(), nil)
 		return
@@ -54,7 +53,7 @@ func CreateGP(res http.ResponseWriter, req *http.Request) {
 		INSERT INTO run (name, description, type, command, createdBy)
 		VALUES ($1, $2, $3, $4, $5)
 		RETURNING id
-	`, time.Now().Local().String(), "Genetic Programming (GP)", "gp", "python -m scoop code.py", user["id"])
+	`, fmt.Sprintf("%d-%d", gp.Generations, gp.PopulationSize), "Genetic Programming (GP)", "gp", "python -m scoop code.py", user["id"])
 
 	var runID string
 	err = row.Scan(&runID)
@@ -126,5 +125,6 @@ func CreateGP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	data["runID"] = runID
 	util.JSONResponse(res, http.StatusOK, "It works! 👍🏻", data)
 }

--- a/controller/ml.go
+++ b/controller/ml.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 )
 
 func CreateML(res http.ResponseWriter, req *http.Request) {
@@ -54,7 +53,7 @@ func CreateML(res http.ResponseWriter, req *http.Request) {
 		INSERT INTO run (name, description, type, command, createdBy)
 		VALUES ($1, $2, $3, $4, $5)
 		RETURNING id
-	`, time.Now().Local().String(), "Optimize ML with EA", "ml", "python -m scoop code.py", user["id"])
+	`, fmt.Sprintf("%d-%d", ml.Generations, ml.PopulationSize), "Optimize ML with EA", "ml", "python -m scoop code.py", user["id"])
 
 	var runID string
 	err = row.Scan(&runID)
@@ -126,5 +125,6 @@ func CreateML(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	data["runID"] = runID
 	util.JSONResponse(res, http.StatusOK, "It works! 👍🏻", data)
 }

--- a/controller/pso.go
+++ b/controller/pso.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 )
 
 func CreatePSO(res http.ResponseWriter, req *http.Request) {
@@ -54,7 +53,7 @@ func CreatePSO(res http.ResponseWriter, req *http.Request) {
 		INSERT INTO run (name, description, type, command, createdBy)
 		VALUES ($1, $2, $3, $4, $5)
 		RETURNING id
-	`, time.Now().Local().String(), "Particle Swarm Optimization", "pso", "python code.py", user["id"])
+	`, fmt.Sprintf("%d-%d", pso.Generations, pso.PopulationSize), "Particle Swarm Optimization", "pso", "python code.py", user["id"])
 
 	var runID string
 	err = row.Scan(&runID)
@@ -126,5 +125,6 @@ func CreatePSO(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	data["runID"] = runID
 	util.JSONResponse(res, http.StatusOK, "It works! 👍🏻", data)
 }


### PR DESCRIPTION
This pull request includes several updates to the `controller` package to improve the handling of different algorithm types and enhance the response data. The main changes include removing unused imports, updating the `Create` functions for different algorithms, and adding more descriptive run names and descriptions.

### Import Cleanup:
* Removed the unused `time` import from `controller/ea.go`, `controller/gp.go`, `controller/ml.go`, and `controller/pso.go`. [[1]](diffhunk://#diff-b0764fc6af665be947c79306075f08e3bf1bfca3105597f4c9a39ed3b186b11bL11) [[2]](diffhunk://#diff-2fe6422fbc872e0ff144eddbe0effedef2485f7eb3977944f0013d97f4baac29L11) [[3]](diffhunk://#diff-9c54596ffb125799a5da0932a30caf228acefdcf552069f3c5744102b6987ee8L11) [[4]](diffhunk://#diff-678f12430cbe8331955558bdc3a98e80563a4015c42ae076eebee664bb192a5dL11)

### Create Function Updates:
* [`controller/ea.go`](diffhunk://#diff-b0764fc6af665be947c79306075f08e3bf1bfca3105597f4c9a39ed3b186b11bR52-R63): Added a `description` variable to differentiate between "Differential Evolution (DE)" and "Evolutionary Algorithm (EA)" based on the `Algorithm` field. Updated the `INSERT INTO run` statement to use a formatted string for the run name and the new `description` variable.
* [`controller/gp.go`](diffhunk://#diff-2fe6422fbc872e0ff144eddbe0effedef2485f7eb3977944f0013d97f4baac29L34-R39): Corrected the variable name from `ea` to `gp` and updated the `INSERT INTO run` statement to use a formatted string for the run name. [[1]](diffhunk://#diff-2fe6422fbc872e0ff144eddbe0effedef2485f7eb3977944f0013d97f4baac29L34-R39) [[2]](diffhunk://#diff-2fe6422fbc872e0ff144eddbe0effedef2485f7eb3977944f0013d97f4baac29L57-R56)
* [`controller/ml.go`](diffhunk://#diff-9c54596ffb125799a5da0932a30caf228acefdcf552069f3c5744102b6987ee8L57-R56): Updated the `INSERT INTO run` statement to use a formatted string for the run name.
* [`controller/pso.go`](diffhunk://#diff-678f12430cbe8331955558bdc3a98e80563a4015c42ae076eebee664bb192a5dL57-R56): Updated the `INSERT INTO run` statement to use a formatted string for the run name.

### Response Data Enhancement:
* Added the `runID` to the response data in `CreateEA`, `CreateGP`, `CreateML`, and `CreatePSO` functions to provide more context in the JSON response. [[1]](diffhunk://#diff-b0764fc6af665be947c79306075f08e3bf1bfca3105597f4c9a39ed3b186b11bR135) [[2]](diffhunk://#diff-2fe6422fbc872e0ff144eddbe0effedef2485f7eb3977944f0013d97f4baac29R128) [[3]](diffhunk://#diff-9c54596ffb125799a5da0932a30caf228acefdcf552069f3c5744102b6987ee8R128) [[4]](diffhunk://#diff-678f12430cbe8331955558bdc3a98e80563a4015c42ae076eebee664bb192a5dR128)